### PR TITLE
Remote build fixes + support for Swift SDK

### DIFF
--- a/core/swift42Action/defaultBuild
+++ b/core/swift42Action/defaultBuild
@@ -24,20 +24,18 @@
 # or (2) when there is a single .swift file.  It exits with an error otherwise.
 # It is my impression that this limitation is inherent in /bin/compile for swift.
 if [ -d "Sources" ] && [ -f "Package.swift" ]; then
-  CURRENT="$PWD"
-	pushd /swiftAction
-	$OW_COMPILER main $CURRENT $CURRENT
-	popd
-  else
-	COUNT=$(ls *.swift | wc -w)
-	if [ "$COUNT" != "1" ]; then
-		echo "Conditions for use of the default action are not met"
-		exit 1
-	fi
-	cp *.swift /swiftAction/exec
-	pushd /swiftAction
-	$OW_COMPILER main . .
-	popd
-	cp /swiftAction/exec .
+  cp /swiftAction/Sources/_Whisk.swift Sources
+  $OW_COMPILER main . .
+else
+  COUNT=$(ls *.swift | wc -w)
+  if [ "$COUNT" != "1" ]; then
+    echo "Conditions for use of the default action are not met"
+    exit 1
+  fi
+  cp *.swift /swiftAction/exec
+  pushd /swiftAction
+  $OW_COMPILER main . .
+  popd
+  mv /swiftAction/exec .
 fi
 echo exec > .include

--- a/core/swift42Action/swiftbuild.py
+++ b/core/swift42Action/swiftbuild.py
@@ -77,13 +77,13 @@ def build(source_dir, target_file, buildcmd):
         print(e)
         print(o)
         print(r)
-        return
+        sys.exit(1)
 
     bin_file = "%s/.build/release/Action" % source_dir
     os.rename(bin_file, target_file)
     if not os.path.isfile(target_file):
         print("failed %s -> %s" % (bin_file, target_file))
-        return
+        sys.exit(1)
 
 
 def main(argv):

--- a/core/swift54Action/Dockerfile
+++ b/core/swift54Action/Dockerfile
@@ -48,6 +48,15 @@ RUN rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get -qq update \
 ARG NIM_INSTALL_SCRIPT=https://apigcp.nimbella.io/downloads/nim/nim-install-linux.sh
 RUN curl ${NIM_INSTALL_SCRIPT} | bash
 
+# Add dynamic libraries for the Swift SDK
+ARG NIM_SDK_ORG=nimbella
+ARG NIM_SDK_BRANCH=master
+RUN cd /tmp && git clone https://github.com/${NIM_SDK_ORG}/nimbella-sdk-swift \
+    && cd nimbella-sdk-swift && git checkout ${NIM_SDK_BRANCH} \
+    && cd lib && swift build -c release \
+    && cp .build/release/*.so /usr/local/lib \
+    && cd ../.. && rm -fr nimbella-sdk-swift
+
 ENV LANG="en_US.UTF-8" \
 	LANGUAGE="en_US:en" \
 	LC_ALL="en_US.UTF-8"

--- a/core/swift54Action/defaultBuild
+++ b/core/swift54Action/defaultBuild
@@ -24,20 +24,18 @@
 # or (2) when there is a single .swift file.  It exits with an error otherwise.
 # It is my impression that this limitation is inherent in /bin/compile for swift.
 if [ -d "Sources" ] && [ -f "Package.swift" ]; then
-  CURRENT="$PWD"
-	pushd /swiftAction
-	$OW_COMPILER main $CURRENT $CURRENT
-	popd
-  else
-	COUNT=$(ls *.swift | wc -w)
-	if [ "$COUNT" != "1" ]; then
-		echo "Conditions for use of the default action are not met"
-		exit 1
-	fi
-	cp *.swift /swiftAction/exec
-	pushd /swiftAction
-	$OW_COMPILER main . .
-	popd
-	cp /swiftAction/exec .
+  cp /swiftAction/Sources/_Whisk.swift Sources
+  $OW_COMPILER main . .
+else
+  COUNT=$(ls *.swift | wc -w)
+  if [ "$COUNT" != "1" ]; then
+    echo "Conditions for use of the default action are not met"
+    exit 1
+  fi
+  cp *.swift /swiftAction/exec
+  pushd /swiftAction
+  $OW_COMPILER main . .
+  popd
+  mv /swiftAction/exec .
 fi
 echo exec > .include

--- a/core/swift54Action/swiftbuild.py
+++ b/core/swift54Action/swiftbuild.py
@@ -71,13 +71,11 @@ def swift_build(dir, buildcmd):
 
 def build(source_dir, target_file, buildcmd):
     r, o, e = swift_build(source_dir, buildcmd)
-    #if e: print(e)
-    #if o: print(o)
+    if o: print(o)
     if r != 0:
-        print(e)
-        print(o)
-        print(r)
-        sys.exit(1)
+        print("rc = %d" % r, file=sys.stderr)
+        if e: print(e, file=sys.stderr)
+        sys.exit(r)
 
     bin_file = "%s/.build/release/Action" % source_dir
     os.rename(bin_file, target_file)

--- a/core/swift54Action/swiftbuild.py
+++ b/core/swift54Action/swiftbuild.py
@@ -77,13 +77,13 @@ def build(source_dir, target_file, buildcmd):
         print(e)
         print(o)
         print(r)
-        return
+        sys.exit(1)
 
     bin_file = "%s/.build/release/Action" % source_dir
     os.rename(bin_file, target_file)
     if not os.path.isfile(target_file):
         print("failed %s -> %s" % (bin_file, target_file))
-        return
+        sys.exit(1)
 
 
 def main(argv):


### PR DESCRIPTION
This PR offers several improvements.   It replaces a PR against the corresponding repo in the `nimbella-corp` organization, which has been replaced by this repo.   Note that the issues have not moved so I still refer to issues in the old repo.

1. It fixes a problem with the exit code from `/bin/compile` (see issue nimbella-corp/openwhisk-runtime-swift#2).
2. It fixes another `/bin/compile` problem: it was swallowing the output of successful builds, which defeats the purpose of `--verbose-build`.
3. It fixes a problem with warm containers that had previously used `/bin/defaultBuild` on a multi-file (Swift Package Manager) build (see issue nimbella-corp/openwhisk-runtime-swift#3).
4. It incorporates the dynamic library portion of the buiid for https://github.com/nimbella/nimbella-SDK-swift, so that the S3 storage provider in that SDK becomes operational.   Without this pre-populating of the runtime, the binaries built using the SDK would be too large.

We should consider removing the last bit.  It only makes sense if the Swift SDK is going to go live in a form which includes the storage provider.   That is likely to happen quite a bit later, if at all.