### PR TITLE
Fail when curl download of nim fails

### DIFF
--- a/core/swift42Action/Dockerfile
+++ b/core/swift42Action/Dockerfile
@@ -45,6 +45,7 @@ RUN rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update \
 
 # Add nim
 ARG NIM_INSTALL_SCRIPT=https://apigcp.nimbella.io/downloads/nim/nim-install-linux.sh
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl ${NIM_INSTALL_SCRIPT} | bash
 
 ENV LANG="en_US.UTF-8" \

--- a/core/swift54Action/Dockerfile
+++ b/core/swift54Action/Dockerfile
@@ -46,6 +46,7 @@ RUN rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get -qq update \
 
 # Add nim
 ARG NIM_INSTALL_SCRIPT=https://apigcp.nimbella.io/downloads/nim/nim-install-linux.sh
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl ${NIM_INSTALL_SCRIPT} | bash
 
 ENV LANG="en_US.UTF-8" \


### PR DESCRIPTION
Removes the possibility that a failure to download nim and hence install it is swallowed and not noticed at image build time.