### PR TITLE
Exit nonzero on build error; show stderr

### DIFF
--- a/core/swift54Action/swiftbuild.py
+++ b/core/swift54Action/swiftbuild.py
@@ -71,19 +71,17 @@ def swift_build(dir, buildcmd):
 
 def build(source_dir, target_file, buildcmd):
     r, o, e = swift_build(source_dir, buildcmd)
-    #if e: print(e)
-    #if o: print(o)
+    if o: print(o)
     if r != 0:
-        print(e)
-        print(o)
-        print(r)
-        return
+        print("rc = %d" % r, file=sys.stderr)
+        if e: print(e, file=sys.stderr)
+        sys.exit(r)
 
     bin_file = "%s/.build/release/Action" % source_dir
     os.rename(bin_file, target_file)
     if not os.path.isfile(target_file):
         print("failed %s -> %s" % (bin_file, target_file))
-        return
+        sys.exit(1)
 
 
 def main(argv):


### PR DESCRIPTION
The python script in `/bin/compile` doesn't set a non-zero exit code when the compilation fails.   Also, it swallows the output of the build.   Although was probably ok in the original action loop context for which it was written, it is a problem when run as a subroutine of remote build because it is then being driven indirectly by a developer who may need to diagnose the failure.   Remote build uses the exit code to decide if the build failed and will then return the output of the build to the developer.

This PR changes the script (sourced as `swiftbuild.py`) for swift 5.4 to correct these problems.