### PR TITLE
Distinguish output/error management in compile script by context

### DIFF
--- a/core/swift54Action/defaultBuild
+++ b/core/swift54Action/defaultBuild
@@ -23,6 +23,8 @@
 # Note that it works when (1) there is a Package.swift and Sources (the multi-file case)
 # or (2) when there is a single .swift file.  It exits with an error otherwise.
 # It is my impression that this limitation is inherent in /bin/compile for swift.
+set -e
+export __NIM_REMOTE_BUILD=true
 if [ -d "Sources" ] && [ -f "Package.swift" ]; then
   CURRENT="$PWD"
 	pushd /swiftAction

--- a/core/swift54Action/swiftbuild.py
+++ b/core/swift54Action/swiftbuild.py
@@ -71,18 +71,24 @@ def swift_build(dir, buildcmd):
 
 def build(source_dir, target_file, buildcmd):
     r, o, e = swift_build(source_dir, buildcmd)
-    if o: print(o)
-    if r != 0:
-        print("rc = %d" % r, file=sys.stderr)
+    if os.environ.get("__NIM_REMOTE_BUILD")
+        if o: print(o)
         if e: print(e, file=sys.stderr)
-        sys.exit(r)
-
+        if r != 0:
+            print("rc = %d" % r, file=sys.stderr)
+            sys.exit(r)
+    else:
+        if r != 0:
+            print(e)
+            print(o)
+            print(r)
+            return
+    
     bin_file = "%s/.build/release/Action" % source_dir
     os.rename(bin_file, target_file)
     if not os.path.isfile(target_file):
         print("failed %s -> %s" % (bin_file, target_file))
         sys.exit(1)
-
 
 def main(argv):
     if len(argv) < 4:


### PR DESCRIPTION
If running under go proxy in compile-on-demand action loop, the upstream logic should govern.  If running under `defaultBuild` under `nim` all output should be available, and error should cause a non-zero exit.

Also adds set -e to `defaultBuild` so that non-zero exits will flow up the call chain.

I only made the change in swift 5.4 on the grounds that we will not be supporting 4.2 with any new functionality. 